### PR TITLE
Add `jsonwebtoken`, `rustls` and `tracing` feature flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["auth0", "authorization", "client", "api"]
 categories = ["api-bindings", "authentication"]
 
 [dependencies]
-alcoholic_jwt = "4091.0.0"
+jsonwebtoken = "9.3.0"
 async-trait = "0.1.61"
 chrono = { version = "0.4.23", features = ["serde"] }
 dotenv = "0.15.0"
@@ -20,11 +20,15 @@ lazy_static = "1.4.0"
 log = "0.4.17"
 pretty_env_logger = "0.4.0"
 regex = "1.7.1"
-reqwest = { version = "0.11.13", features = ["json"] }
+reqwest = { version = "0.12.4", default-features = false, features = [
+    "json",
+    "rustls-tls",
+] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"
 thiserror = "1.0.38"
 urlencoding = "2.1.2"
+tracing = "0.1.40"
 
 [dev-dependencies]
 mockito = "0.31.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,17 +12,17 @@ keywords = ["auth0", "authorization", "client", "api"]
 categories = ["api-bindings", "authentication"]
 
 [dependencies]
-jsonwebtoken = "9.3.0"
+jsonwebtoken = "10.3.0"
 async-trait = "0.1.61"
 chrono = { version = "0.4.23", features = ["serde"] }
 dotenv = "0.15.0"
 lazy_static = "1.4.0"
 log = "0.4.17"
-pretty_env_logger = "0.4.0"
+pretty_env_logger = "0.5.0"
 regex = "1.7.1"
-reqwest = { version = "0.12.4", default-features = false, features = [
-    "json",
-    "rustls-tls",
+reqwest = { version = "0.13.2", default-features = false, features = [
+  "json",
+  "rustls",
 ] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,5 @@
 //! Types relative to error handling.
 
-use alcoholic_jwt::ValidationError;
 use reqwest::Error as ReqwestError;
 use serde::Deserialize;
 use serde_json::Error as SerdeJsonError;
@@ -24,7 +23,10 @@ pub enum Error {
     #[error("Missing kid in JWT")]
     JwtMissingKid,
     #[error("Invalid JWT: {0}")]
-    InvalidJwt(#[from] ValidationError),
+    InvalidJwt(#[from] jsonwebtoken::errors::Error),
+    // this is an internal error and should be considered a bug. That's why I'm not returning any aditional info
+    #[error("Invalid JWK")]
+    InvalidJwk,
     #[error("Serialization error: {0}")]
     Serialization(#[from] SerdeJsonError),
     #[error("Reqwest error: {0}")]

--- a/src/users.rs
+++ b/src/users.rs
@@ -231,7 +231,7 @@ pub struct CheckPasswordPayload {
 pub struct UserResponse {
     pub user_id: String,
     pub email: Option<String>,
-    pub email_verified: bool,
+    pub email_verified: Option<bool>,
     pub name: String,
     pub nickname: String,
     pub picture: String,


### PR DESCRIPTION
Replace `alcoholic_jwt` with `jsonwebtoken`, replace `log` with `tracing` and use `reqwest` without depending on `openssl` system library.

This is breaking if a project depends on this crate with `default-features = false`.
Either `alcoholic_jwt` or `jsonwebtoken` have to be enabled, but not both (checked with `compile_error!` calls).
Either `log` or `tracing` have to be enabled, but not both (checked with `compile_error!` calls).

If a project depends on this crate with `default-features = true` (default), this is non-breaking since the default features are `alcoholic_jwt`, `log` and `reqwest/default-tls`, which keeps the current behavior.

The `rustls` feature, enables `reqwest/rustls-tls` and `jsonwebtoken`. `jsonwebtoken` doesn't depend on OpenSSL whereas `alcoholic_jwt` does.

Tests are passing with either `jsonwebtoken` or `alcoholic_jwt`.

Added a new example for `valid_jwt`. Kept the one using `alcoholic_jwt` and added one using `jsonwebtoken`.

