### PR TITLE
Unused dependencies triggering 'cargo audit' report.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,8 @@ categories = ["api-bindings", "authentication"]
 alcoholic_jwt = "4091.0.0"
 async-trait = "0.1.61"
 chrono = { version = "0.4.23", features = ["serde"] }
-dotenv = "0.15.0"
 lazy_static = "1.4.0"
 log = "0.4.17"
-pretty_env_logger = "0.4.0"
 regex = "1.7.1"
 reqwest = { version = "0.11.13", features = ["json"] }
 serde = { version = "1.0.152", features = ["derive"] }


### PR DESCRIPTION
`dotenv` and `pretty_env_logger` are not even used... yet they create warnings running `cargo audit`

```
tjo@strix-tjo ~/auth0_client_rs ((HEAD detached at 3519c6c))$ cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 745 security advisories (from /home/tjo/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (196 crate dependencies)
Crate:     atty
Version:   0.2.14
Warning:   unmaintained
Title:     `atty` is unmaintained
Date:      2024-09-25
ID:        RUSTSEC-2024-0375
URL:       https://rustsec.org/advisories/RUSTSEC-2024-0375
Dependency tree:
atty 0.2.14
└── env_logger 0.7.1
    └── pretty_env_logger 0.4.0
        └── auth0_client 0.2.2

Crate:     dotenv
Version:   0.15.0
Warning:   unmaintained
Title:     dotenv is Unmaintained
Date:      2021-12-24
ID:        RUSTSEC-2021-0141
URL:       https://rustsec.org/advisories/RUSTSEC-2021-0141
Dependency tree:
dotenv 0.15.0
└── auth0_client 0.2.2

Crate:     atty
Version:   0.2.14
Warning:   unsound
Title:     Potential unaligned read
Date:      2021-07-04
ID:        RUSTSEC-2021-0145
URL:       https://rustsec.org/advisories/RUSTSEC-2021-0145

warning: 3 allowed warnings found
```